### PR TITLE
GitHub Action to build & upload `openqasm` package on new tag

### DIFF
--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.9']
         antlr-version: ['4.9.2']
     defaults:
       run:

--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -1,7 +1,6 @@
 name: Publish QAMP2021 test Reference Python Package
 
-on:
-  [tag]
+on: [push, pull_request]
 
 jobs:
   publish:

--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -55,3 +55,4 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           repository_url: https://test.pypi.org/legacy
+          packages_dir: source/openqasm

--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -1,0 +1,58 @@
+name: Publish QAMP2021 test Reference Python Package
+
+on:
+  [tag]
+
+jobs:
+  publish:
+    name: Publish qamp2021-test-openqasm python package
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        antlr-version: ['4.9.2']
+    defaults:
+      run:
+        working-directory: source/openqasm
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '15'
+          distribution: 'adopt'
+
+      - name: Update pip
+        run: python -mpip install --upgrade pip
+
+      - name: Install ANTLR4
+        working-directory: source/grammar
+        run: curl -O https://www.antlr.org/download/antlr-${{ matrix.antlr-version }}-complete.jar
+
+      - name: Install ANTLR4 Python runtime
+        run: python -mpip install antlr4-python3-runtime==${{ matrix.antlr-version }}
+
+      - name: Generate grammar
+        working-directory: source/grammar
+        run: java -Xmx500M -jar antlr-${{ matrix.antlr-version }}-complete.jar -o ../openqasm/openqasm3/antlr -Dlanguage=Python3 -visitor qasm3.g4
+
+      - name: Install build dependencies
+        run: python -m pip install build wheel
+
+      - name: Build distributions
+        shell: bash -l {0}
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish package to PyPI
+        if: github.repository == 'nelimee/openqasm' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          repository_url: https://test.pypi.org/legacy

--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -55,4 +55,4 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           repository_url: https://test.pypi.org/legacy
-          packages_dir: source/openqasm
+          packages_dir: source/openqasm/dist/

--- a/.github/workflows/publish-openqasm-parser-package.yml
+++ b/.github/workflows/publish-openqasm-parser-package.yml
@@ -54,5 +54,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
-          repository_url: https://test.pypi.org/legacy
+          repository_url: https://test.pypi.org/legacy/
           packages_dir: source/openqasm/dist/

--- a/source/openqasm/setup.cfg
+++ b/source/openqasm/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-name = openqasm3
-url = https://github.com/Qiskit/openqasm
+name = qamp2021-test-openqasm3
+url = https://github.com/nelimee/openqasm
 author = OpenQASM Contributors
 description = Reference OpenQASM AST in Python
 long_description = file: README.md

--- a/source/openqasm/setup.py
+++ b/source/openqasm/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the Qiskit Advocate Mentorship Program we would like to be able to publish our work as a Python package and require a working `openqasm` parser that can be added as a dependency. 

This pull request introduces a new GitHub workflow that will build & publish the `openqasm` Python package automatically when a new tag is pushed.

### Details and comments

1. A PyPi authentication token should be uploaded as a GitHub Secret under the name "PYPI_PASSWORD".
2. I explicitly changed the package name before uploading anything, not wanting to create any issue in the future.
3. The **test** package has been uploaded on https://test.pypi.com (see https://test.pypi.org/project/qamp2021-test-openqasm3/) and can be installed using `python -m pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple qamp2021-test-openqasm3[parser]`.

#### A few possible improvements:

1. Make the GitHub action dependent on the successful execution of the tests.
2. Revert the package name to `openqasm` (along with action name and several other things).
3. Change `github.repository == 'nelimee/openqasm'` to `github.repository == 'Qiskit/openqasm'`.
4. Find a way to encode the ANTLR version only once (currently it is duplicated in the action `antlr-version: ['4.9.2']` and in the `requirements.txt`).

Should in theory fix https://github.com/Qiskit/openqasm/issues/304.